### PR TITLE
add pass by value v.s. reference files

### DIFF
--- a/passByReferenceTest.sol
+++ b/passByReferenceTest.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.8.0;
+
+contract ReferenceTypes{
+
+  //pass by ref
+  uint256[] public x = [1,2,3,4];
+  
+  function realTest() external{
+    //passing uint[] to the function
+    _changeSth(x);
+  }
+  
+  // x is cloned into n
+  function _changeSth(uint[] storage n) internal returns(uint[] memory){
+    n[0] *= 100;
+    return n;
+  }
+}

--- a/passByValueTest.sol
+++ b/passByValueTest.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.8.0;
+contract ValueTypes{
+
+  //pass by value
+  uint256 public x = 10;
+  
+  function realTest() external view{
+    //passing uint to the function
+    _changeSth(x);
+  }
+  
+  // x is cloned into n
+  function _changeSth(uint n) internal pure returns(uint){
+    n *= 2;
+    return n;
+  }
+}


### PR DESCRIPTION
Primitive types like integer and boolean are also called value types because variables of these types will always be passed by value, i.e. they are always copied when they are used as function arguments or in assignments.

On the other hand, values of reference type are passed to a function by a pointer and can be modified through multiple different names. Contrast this with value types where you get an independent copy whenever a variable of value type is used.
